### PR TITLE
Call setupQuizHTML from initializeQuiz

### DIFF
--- a/src/init/initializeQuiz.js
+++ b/src/init/initializeQuiz.js
@@ -8,7 +8,7 @@ import { quizData } from '../data.js';
 
 const initializeQuiz = () => {
   quizData.currentQuestionIndex = 0;
-
+  setupQuizHTML();
   showCurrentQuestion();
 };
 


### PR DESCRIPTION
When starting the quiz the page is not loaded because the setup is not actually called: the initialiser `initializeQuiz` is called, but it does not call the `setupQuizHTML` function. 
Because of this nothing is shown. I thought this might be something for the students to figure out (and was missing intentionally). However no one seems to be able when this far in the curriculum, to find this out for themselves: getting used to multiple files and importing and exporting is already a (big) challenge.