### PR TITLE
fix: remove legacy npm scripts

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,4 +17,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - run: npm ci
       - run: npm run prettier:check

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,43 +1,20 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: merge-changes
 
-on:
-  pull_request:
-    branches: [master, main]
+on: [push]
 
 jobs:
-  document-and-test:
-    runs-on: ubuntu-18.04
+  lint:
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
-      - run: npm install
-      - uses: stefanzweifel/git-auto-commit-action@v4.7.2
-        with:
-          commit_message: installing
-          branch: ${{ github.head_ref }}
-
-      - run: npm run document
-      - uses: stefanzweifel/git-auto-commit-action@v4.7.2
-        with:
-          commit_message: documenting
-          branch: ${{ github.head_ref }}
-
-      - run: npm run test-ci
-        env:
-          CI: true
-      - uses: stefanzweifel/git-auto-commit-action@v4.7.2
-        with:
-          commit_message: testing
-          branch: ${{ github.head_ref }}
+      - run: npm run prettier:check

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "js-quiz-starter",
   "version": "1.0.0",
   "scripts": {
-    "prettier": "prettier --write ."
+    "prettier:write": "prettier --write .",
+    "prettier:check": "prettier --check ."
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,7 @@
   "name": "js-quiz-starter",
   "version": "1.0.0",
   "scripts": {
-    "document": "node ./lib/document.js",
-    "prettier": "prettier --write .",
-    "test": "node ./lib/test.js",
-    "test-ci": "node ./lib/test.js CI"
+    "prettier": "prettier --write ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Some of the scripts defined in `package.json` refer to files that don't exist anymore. 
- GitHub actions fail on every commit, and it also creates a new commit on every PR...

I removed the legacy scripts, and update the GH action to run prettier on CI. 